### PR TITLE
Quickly changed special relativity

### DIFF
--- a/tex/SpecialRelativity.tex
+++ b/tex/SpecialRelativity.tex
@@ -177,10 +177,10 @@ As a corollary to Einstein's postulates, we will see that nothing can ever excee
 \end{checkpoint}
 \begin{checkpoint}{}
 	\begin{MCquestion}{What speed corresponds to a gamma of \SI{2.5}{}?}
-		\item \SI{2.5c}{}. 
-		\item \SI{0.92c}{}. \correct
-		\item \SI{0.25c}{}.
-		\item \SI{0.47c}{}.
+		\item $2.5c$ 
+		\item $0.92c$. \correct
+		\item $0.25c$.
+		\item $0.47c$.
 	\end{MCquestion}
 \end{checkpoint}
 
@@ -268,10 +268,10 @@ L'_{train}=\frac{(\SI{500}{m})}{2.5}=\SI{200}{m}
 
 \begin{checkpoint}{}
 	\begin{MCquestion}{What speed must an object travel in order for it to appear \SI{1}{\percent} shorter}
-		\item \SI{0.01c}{}. 
-		\item \SI{0.04c}{}. \correct
-		\item \SI{0.99c}{}.
-		\item \SI{0.65c}{}.
+		\item $0.01c$. 
+		\item $0.04c$. \correct
+		\item $0.99c$.
+		\item $0.65c$.
 	\end{MCquestion}
 \end{checkpoint}
 
@@ -919,7 +919,6 @@ Which is our final answer. The energy produced in this reaction may seem insigni
 	d& = v\gamma t\\
 	d & = \frac{vt}{1-\frac{v^2}{c^}}\\
 	d &= \frac{(\SI{2.78e8}{ms^{-1}})(\SI{1}{s})}{1-\frac{(\SI{2.78e8}{ms^{-1}})^2}{(\SI{2.998e8}{ms^{-1}})^2}}\\
-	
 	\end{align*}
 	\end{enumerate}
 \end{solution}


### PR DESCRIPTION
LaTeX ddin't like me putting a "c" in \SI, so I just changed it to math with $0.99c$ (as an example).

Just quickly cleaning an issue in Checkpoint questions so you don't have to deal with it